### PR TITLE
パスワードリセットapi実装

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "express": "^4.21.1",
         "express-session": "^1.18.1",
         "helmet": "^8.0.0",
+        "nodemailer": "^6.9.16",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0"
       },
@@ -25,6 +26,7 @@
         "@types/express": "^5.0.0",
         "@types/express-session": "^1.18.1",
         "@types/node": "^22.10.1",
+        "@types/nodemailer": "^6.4.17",
         "@types/passport": "^1.0.17",
         "@types/passport-local": "^1.0.38",
         "nodemon": "^3.1.7",
@@ -238,6 +240,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/passport": {
@@ -1482,6 +1494,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.16",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.16.tgz",
+      "integrity": "sha512-psAuZdTIRN08HKVd/E8ObdV6NO7NTBY3KsC30F7M4H1OnmLCUNaS56FpYxyb26zWLSyYF9Ozch9KYHhHegsiOQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "express": "^4.21.1",
     "express-session": "^1.18.1",
     "helmet": "^8.0.0",
+    "nodemailer": "^6.9.16",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0"
   },
@@ -29,6 +30,7 @@
     "@types/express": "^5.0.0",
     "@types/express-session": "^1.18.1",
     "@types/node": "^22.10.1",
+    "@types/nodemailer": "^6.4.17",
     "@types/passport": "^1.0.17",
     "@types/passport-local": "^1.0.38",
     "nodemon": "^3.1.7",

--- a/backend/src/serviece/mail.serviece.ts
+++ b/backend/src/serviece/mail.serviece.ts
@@ -1,0 +1,30 @@
+// src/services/mail.service.ts
+import nodemailer from "nodemailer";
+
+const transporter = nodemailer.createTransport({
+  service: "gmail",
+  auth: {
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS,
+  },
+});
+
+export const mailService = {
+  async sendPasswordResetMail(email: string, resetUrl: string) {
+    try {
+      await transporter.sendMail({
+        from: process.env.EMAIL_USER,
+        to: email,
+        subject: "パスワードリセット",
+        text: `パスワードをリセットするには以下のリンクをクリックしてください：\n\n${resetUrl}`,
+        html: `
+          <p>パスワードをリセットするには以下のリンクをクリックしてください：</p>
+          <p><a href="${resetUrl}">パスワードをリセット</a></p>
+        `,
+      });
+    } catch (error) {
+      console.error("Error:", error);
+      throw new Error("メール送信に失敗しました");
+    }
+  },
+};


### PR DESCRIPTION
- バックエンドのみ実装
- `http://localhost:3000/api/auth/passwordReset` にPOSTリクエストでbodyに登録済みのemailを入れてsendするとパスワードリセット画面に遷移するためのTokenつきのURLが入ったメールが送信される